### PR TITLE
[fix] Reduce the size of Java Runtime Environment (JRE) when downloaded 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ index.js
 index.js.map
 
 test-output
+.DS_Store

--- a/index.ts
+++ b/index.ts
@@ -366,7 +366,7 @@ export namespace kratosRuntime {
         "architecture",
         (options && options.arch) || "x64"
       );
-      url.searchParams.append("image_type", "jdk");
+      url.searchParams.append("image_type", "jre");
       url.searchParams.append("os", (options && options.os) || "windows");
       url.searchParams.append("vendor", "eclipse");
 

--- a/index.ts
+++ b/index.ts
@@ -279,6 +279,7 @@ export namespace kratosRuntime {
     version?: number;
     arch?: RuntimeBuildArchitecture;
     os?: RuntimeBuildOs;
+    image_type?: "jdk" | "jre";
   }
 
   interface Package {
@@ -366,7 +367,10 @@ export namespace kratosRuntime {
         "architecture",
         (options && options.arch) || "x64"
       );
-      url.searchParams.append("image_type", "jre");
+      url.searchParams.append(
+        "image_type",
+        (options && options.image_type) || "jdk"
+      );
       url.searchParams.append("os", (options && options.os) || "windows");
       url.searchParams.append("vendor", "eclipse");
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kratos-runtime-resolver",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "license": "MIT",
   "description": "The JDK resolver for Kratos Launcher",

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -322,6 +322,19 @@ describe("[unit] RuntimeRepositoryManager", () => {
     ).to.eq(
       `https://api.adoptium.net/v3/assets/latest/-1/hotspot?architecture=x64&image_type=jdk&os=windows&vendor=eclipse`
     );
+
+    expect(
+      repositoryManager
+        .buildJdkPackageInfoUrl({
+          version: 8,
+          arch: "x64",
+          os: "mac",
+          image_type: "jre",
+        })
+        .toString()
+    ).to.eq(
+      `https://api.adoptium.net/v3/assets/latest/8/hotspot?architecture=x64&image_type=jre&os=mac&vendor=eclipse`
+    );
   });
 
   it(`should throw with invalid architecture or platform`, () => {
@@ -351,6 +364,26 @@ describe("[unit] RuntimeRepositoryManager", () => {
     let downloadInfo = await downloadProcess.startDownload();
     expect(existsSync(downloadInfo.destination)).to.be.true;
 
+    // Then remove the file
+    rmSync("download", { force: true, recursive: true });
+  });
+
+  it(`should install a jre`, async function () {
+    if (SKIP_DOWNLOAD_TEST) {
+      return this.skip();
+    }
+
+    this.timeout(50000);
+    const downloadProcess =
+      await repositoryManager.createRuntimeDownloadProcess(
+        { version: 8, arch: "x64", os: "windows", image_type: "jre" },
+        pathJoin(TEST_OUTPUT, "download", "runtime", "8.tar.gz")
+      );
+
+    expect(downloadProcess).not.to.be.undefined;
+
+    let downloadInfo = await downloadProcess.startDownload();
+    expect(existsSync(downloadInfo.destination)).to.be.true;
     // Then remove the file
     rmSync("download", { force: true, recursive: true });
   });


### PR DESCRIPTION
# Changes
Using `jre` url, which have a smaller file size than `jdk` 